### PR TITLE
Add JUnit test skeleton

### DIFF
--- a/Database_Management_E/source/DB_Management_E/nbproject/project.properties
+++ b/Database_Management_E/source/DB_Management_E/nbproject/project.properties
@@ -27,11 +27,13 @@ dist.dir=dist
 dist.jar=${dist.dir}/DB_Management_E.jar
 dist.javadoc.dir=${dist.dir}/javadoc
 excludes=
-file.reference.mysql-connector-java-5.1.38-bin.jar=C:\\Users\\Loco\\Desktop\\mysql-connector-java-5.1.38\\mysql-connector-java-5.1.38-bin.jar
+file.reference.mysql-connector-java-5.1.38-bin.jar=../../lib/mysql-connector-java-5.1.38-bin.jar
+file.reference.junit4.jar=/usr/share/java/junit4.jar
 includes=**
 jar.compress=false
 javac.classpath=\
-    ${file.reference.mysql-connector-java-5.1.38-bin.jar}
+    ${file.reference.mysql-connector-java-5.1.38-bin.jar}:\
+    ${file.reference.junit4.jar}
 # Space-separated list of extra javac options
 javac.compilerargs=
 javac.deprecation=false

--- a/Database_Management_E/source/DB_Management_E/test/db_management/DB_InterfaceTest.java
+++ b/Database_Management_E/source/DB_Management_E/test/db_management/DB_InterfaceTest.java
@@ -1,0 +1,67 @@
+package db_management;
+
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+
+import java.lang.reflect.Field;
+
+import javax.swing.JPasswordField;
+import javax.swing.JTextField;
+import javax.swing.JLabel;
+
+import org.junit.Test;
+
+import sun.misc.Unsafe;
+import java.lang.reflect.Modifier;
+
+public class DB_InterfaceTest {
+
+    private static Unsafe getUnsafe() throws Exception {
+        Field f = Unsafe.class.getDeclaredField("theUnsafe");
+        f.setAccessible(true);
+        return (Unsafe) f.get(null);
+    }
+
+    private DB_Interface createInstance() throws Exception {
+        Unsafe unsafe = getUnsafe();
+        DB_Interface obj = (DB_Interface) unsafe.allocateInstance(DB_Interface.class);
+        setField(obj, "User", new JTextField());
+        setField(obj, "Password", new JPasswordField());
+        setField(obj, "IPadress", new JTextField());
+        setField(obj, "StatusLed", new JLabel());
+        setField(obj, "Status", new JLabel());
+        return obj;
+    }
+
+    private void setField(DB_Interface obj, String name, Object value) throws Exception {
+        Field f = DB_Interface.class.getDeclaredField(name);
+        f.setAccessible(true);
+        if (Modifier.isStatic(f.getModifiers())) {
+            f.set(null, value);
+        } else {
+            f.set(obj, value);
+        }
+    }
+
+    @Test
+    public void testConnectWithInvalidCredentials() throws Exception {
+        System.setProperty("java.awt.headless", "true");
+        DB_Interface db = createInstance();
+        setFieldValue(db, "User", "invalid");
+        setFieldValue(db, "Password", "invalid");
+        setFieldValue(db, "IPadress", "127.0.0.1");
+        assertThrows(Exception.class, () -> db.connect());
+        assertNull(DB_Interface.dbcoConnection);
+    }
+
+    private void setFieldValue(DB_Interface obj, String field, String val) throws Exception {
+        Field f = DB_Interface.class.getDeclaredField(field);
+        f.setAccessible(true);
+        Object o = f.get(obj);
+        if (o instanceof JTextField) {
+            ((JTextField)o).setText(val);
+        } else if (o instanceof JPasswordField) {
+            ((JPasswordField)o).setText(val);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add JUnit dependency path for ant build
- create DB_InterfaceTest that allocates the DB_Interface class in headless mode

## Testing
- `ant -noinput -q test`

------
https://chatgpt.com/codex/tasks/task_e_683ffa2d564c832988da27a6d6673629